### PR TITLE
Change dev/prod mode

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -2,4 +2,6 @@
 
 const oclif = require('@oclif/core')
 
+process.env.NODE_ENV = 'production'
+
 oclif.run().then(require('@oclif/core/flush')).catch(require('@oclif/core/handle'))

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "prepack": "NODE_ENV=production yarn build && oclif manifest && oclif readme",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif readme && git add README.md",
-    "dev": "dgctl"
+    "dev": "./bin/dev"
   },
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
After this change, `yarn build` will produce the prod version of the CLI (NODE_ENV=production)

To run locally the dev mode, instead of `dgctl`, it will be a bit more convoluted -> `npx -p dgctl yarn dev` (setting an alias to something like `dgdev` would be a good idea). Also - doesn't require a rebuild after code change.

Example usage: `npx -p dgctl yarn dev init`, `npx -p dgctl yarn dev block add -t container`, etc